### PR TITLE
fix: do not use visible for tests

### DIFF
--- a/tests/search-empty.test.js
+++ b/tests/search-empty.test.js
@@ -22,9 +22,8 @@ describe("Check that the empty view shows upon no results", () => {
 
     const isEmptyViewVisible = async (page) => {
       try {
-        await page.waitForSelector("#empty", {
-          visible: true,
-          timeout: 1500,
+        await page.waitForSelector(`#empty:not([style*="display: none"])`, {
+          timeout: 5000,
         });
         return true;
       } catch (e) {

--- a/tests/search-secret-open.test.js
+++ b/tests/search-secret-open.test.js
@@ -23,9 +23,8 @@ describe("Check that the search box is shown only after clicking get", () => {
 
     const isSearchVisible = async (page) => {
       try {
-        await page.waitForSelector("#search-box", {
-          visible: true,
-          timeout: 1500,
+        await page.waitForSelector(`#search-box:not([style*="display: none"])`, {
+          timeout: 5000,
         });
         return true;
       } catch (e) {


### PR DESCRIPTION
It seems that the visible flag caused the puppeteer flags to fail. I changed it to be by a css selector instead.