### PR TITLE
use specific puppeteer version

### DIFF
--- a/steps/search_empty.yml
+++ b/steps/search_empty.yml
@@ -77,5 +77,5 @@ githubActions:
   frontend:
     capabilities:
     - jest-puppeteer
-    - puppeteer
+    - "puppeteer@18.1.0"
     testFile: "search-empty.test.js"

--- a/steps/search_secret_open.yml
+++ b/steps/search_secret_open.yml
@@ -72,5 +72,5 @@ githubActions:
   frontend:
     capabilities:
     - jest-puppeteer
-    - puppeteer
+    - "puppeteer@18.1.0"
     testFile: "search-secret-open.test.js"


### PR DESCRIPTION
This fixes the following error some users got (and myself as well): 
`Cannot find module 'puppeteer-core/internal/common/Device.js' from '../node_modules/puppeteer/lib/cjs/puppeteer/puppeteer.js'`


Solution is based on: https://stackoverflow.com/questions/74078944/cannot-find-module-puppeteer-core-internal-common-device-js