### PR TITLE
Only use jest-puppeteer

### DIFF
--- a/steps/search_empty.yml
+++ b/steps/search_empty.yml
@@ -78,7 +78,6 @@ githubActions:
   frontend:
     capabilities:
     - jest-puppeteer
-    - "puppeteer@18.1.0"
     testFile: "search-empty.test.js"
 solution:
   do:


### PR DESCRIPTION
We don't need to add both now, since it's been added as a capability.